### PR TITLE
Send to firehose asynchronously

### DIFF
--- a/firequeue.go
+++ b/firequeue.go
@@ -116,6 +116,8 @@ type Queue struct {
 	unretryableErrorCount expvar.Int
 	// queueFullErrorCount counts queue full errors when Enqueue() is called.
 	queueFullErrorCount expvar.Int
+	// batchLength is length of the latest batch.
+	batchLength expvar.Int
 }
 
 // Stats return queue stats
@@ -257,6 +259,7 @@ func (q *Queue) sendBatch(bf backoff.BackOff) time.Duration {
 		return q.batchInterval
 	}
 	batch := q.createBatch()
+	q.batchLength.Set(int64(len(batch)))
 	if err := q.attemptToSendBatch(batch); err != nil {
 		// Handle non-retryable errors directly.
 		q.handleError(err, batch)

--- a/firequeue_test.go
+++ b/firequeue_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/firehose"
@@ -46,99 +47,273 @@ type testFirehose struct {
 	counter uint32
 }
 
-func (tf *testFirehose) PutRecord(*firehose.PutRecordInput) (*firehose.PutRecordOutput, error) {
-	if rand.Intn(10) < 2 {
-		// Letting them fail on purpose with a certain probability
-		return nil, &testAWSError{}
+func (tf *testFirehose) PutRecordBatch(input *firehose.PutRecordBatchInput) (*firehose.PutRecordBatchOutput, error) {
+	if rand.Intn(10) > 3 {
+		return &firehose.PutRecordBatchOutput{
+			FailedPutCount: aws.Int64(0),
+		}, nil
 	}
-	atomic.AddUint32(&tf.counter, 1)
-	return &firehose.PutRecordOutput{}, nil
+
+	var failedPutCounter int64
+	inputLength := len(input.Records)
+	firehoseResp := make([]*firehose.PutRecordBatchResponseEntry, inputLength)
+	for i := 0; i < inputLength; i++ {
+		if rand.Intn(10) < 2 {
+			firehoseResp[i] = &firehose.PutRecordBatchResponseEntry{
+				ErrorCode:    aws.String("test_error"),
+				ErrorMessage: aws.String("test_error_message"),
+			}
+			failedPutCounter++
+		} else {
+			firehoseResp[i] = &firehose.PutRecordBatchResponseEntry{
+				RecordId: aws.String(fmt.Sprintf("%d", atomic.LoadUint32(&tf.counter))),
+			}
+		}
+	}
+	resp := &firehose.PutRecordBatchOutput{
+		RequestResponses: firehoseResp,
+		FailedPutCount:   aws.Int64(failedPutCounter),
+	}
+
+	if failedPutCounter > 0 {
+		return resp, &testAWSError{}
+	}
+	return resp, nil
 }
 
-func (tf *testFirehose) PutRecordWithContext(_ context.Context, r *firehose.PutRecordInput, _ ...request.Option) (*firehose.PutRecordOutput, error) {
-	return tf.PutRecord(r)
+func (tf *testFirehose) PutRecordBatchWithContext(_ context.Context, r *firehose.PutRecordBatchInput, _ ...request.Option) (*firehose.PutRecordBatchOutput, error) {
+	return tf.PutRecordBatch(r)
 }
 
+// success
 func TestQueue(t *testing.T) {
 	testCases := []struct {
-		name string
-		opts []firequeue.Option
-	}{{
-		name: "serial",
-	}, {
-		name: "parallel 10",
-		opts: []firequeue.Option{
-			firequeue.Parallel(10),
+		name  string
+		times int
+	}{
+		{
+			name:  "1 record",
+			times: 1,
 		},
-	}}
+		{
+			name:  "50 records",
+			times: 50,
+		},
+		{
+			name:  "100 records",
+			times: 100,
+		},
+		{
+			name:  "1000 records",
+			times: 1000,
+		},
+	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tf := &testFirehose{}
-			q := firequeue.New(tf, tc.opts...)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			q := firequeue.New(tf, "env", firequeue.BatchInterval(100*time.Millisecond))
+			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+			go q.Loop(ctx)
 
-			errch := make(chan error)
-			go func() {
-				errch <- q.Loop(ctx)
-			}()
+			time.Sleep(1000 * time.Millisecond)
 
-			const trial = 10000
-			go func() {
-				for i := 0; i < trial; i++ {
-					go q.Send(&firehose.PutRecordInput{})
+			for i := 0; i < tc.times; i++ {
+				err := q.Enqueue(&firehose.Record{
+					Data: []byte("test"),
+				})
+				if err != nil {
+					t.Errorf("error should not be occurred but: %s", err)
 				}
-			}()
-
-			if err := <-errch; err != nil {
-				t.Errorf("error shoud be nil but: %s", err)
 			}
-
-			if trial != tf.counter {
-				t.Errorf("got: %d, expect: %d", tf.counter, trial)
-			}
-
+			time.Sleep(10 * time.Second)
 			stats := q.Stats()
-			valid := func(s firequeue.Stats) bool {
-				if s.GiveupError > 0 || s.UnretryableError > 0 || s.QueueFullError > 0 || s.QueueLength > 0 {
-					return false
-				}
-				if s.Success+s.RetrySuccess != trial {
-					return false
-				}
-				return s.Success > s.RetrySuccess
+			if stats.Success != int64(tc.times) {
+				t.Log(stats)
+				t.Errorf("Not all records were success. expected: %d, actual: %d", tc.times, stats.Success)
 			}
-			if !valid(stats) {
-				t.Errorf("invalid stats: %+v", stats)
-			}
+			t.Log(q.Stats())
+
 		})
 	}
 }
 
-func TestQueue_Loop(t *testing.T) {
+func TestQueue_Para(t *testing.T) {
+	testCases := []struct {
+		name  string
+		times int
+		para  int
+	}{
+		{
+			name:  "parallel 2",
+			times: 1000,
+			para:  2,
+		},
+		{
+			name:  "parallel 10",
+			times: 1000,
+			para:  10,
+		},
+		{
+			name:  "parallel 100",
+			times: 1000,
+			para:  10,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tf := &testFirehose{}
+			q := firequeue.New(tf, "env", firequeue.BatchInterval(1*time.Second), firequeue.Parallel(tc.para))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go q.Loop(ctx)
+
+			time.Sleep(1000 * time.Millisecond)
+
+			for i := 0; i < tc.times; i++ {
+				err := q.Enqueue(&firehose.Record{
+					Data: []byte("test"),
+				})
+				if err != nil {
+					t.Errorf("error should not be occurred but: %s", err)
+				}
+			}
+			time.Sleep(10 * time.Second)
+			stats := q.Stats()
+			if stats.Success != int64(tc.times) {
+				t.Log(stats)
+				t.Errorf("Not all records were success. expected: %d, actual: %d", tc.times, stats.Success)
+			}
+			t.Log(q.Stats())
+
+		})
+	}
+}
+
+func TestQueue_CallLoopTwoTimes(t *testing.T) {
 	tf := &testFirehose{}
-	q := firequeue.New(tf,
-		firequeue.MaxQueueLength(100),
-		firequeue.ErrorHandler(func(err error, r *firehose.PutRecordInput) {}))
+	q := firequeue.New(tf, "env")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go q.Loop(ctx)
 
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	err := q.Loop(ctx)
 	if err == nil || !strings.Contains(err.Error(), "already initialized") {
+		fmt.Println(err)
 		t.Errorf("already initialized error should be occurred but: %s", err)
 	}
 }
 
-func TestQueue_Send(t *testing.T) {
+func TestQueue_SendWithoutLoop(t *testing.T) {
 	tf := &testFirehose{}
-	q := firequeue.New(tf)
+	q := firequeue.New(tf, "env")
 
-	err := q.Send(nil)
+	err := q.Enqueue(nil)
 	if err == nil || !strings.Contains(err.Error(), "loop has not yet started") {
 		t.Errorf("loop has not yet started error should be occurred but: %s", err)
+	}
+}
+
+func TestQueue_ExceedBatchSize(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("panic should be occurred but not")
+		}
+	}()
+	tf := &testFirehose{}
+	firequeue.New(tf, "env", firequeue.BatchSize(501))
+}
+
+func TestQueue_QueueLength(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("panic should be occurred but not")
+		}
+	}()
+	tf := &testFirehose{}
+	firequeue.New(tf, "env", firequeue.MaxQueueLength(-1))
+}
+
+func TestQueue_DrainProcess(t *testing.T) {
+	tests := []struct {
+		name  string
+		count int
+	}{
+		{"10 records", 10},
+		{"50 records", 50},
+		{"100 records", 100},
+		{"1000 records", 1000},
+		{"2000 records", 2000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := &testFirehose{}
+			q := firequeue.New(tf, "env", firequeue.BatchInterval(1*time.Second))
+			ctx, cancel := context.WithCancel(context.Background())
+			go q.Loop(ctx)
+
+			time.Sleep(1000 * time.Millisecond)
+
+			for i := 0; i < tt.count; i++ {
+				err := q.Enqueue(&firehose.Record{
+					Data: []byte("test"),
+				})
+				if err != nil {
+					t.Errorf("error should not be occurred but: %s", err)
+				}
+			}
+			cancel()
+			time.Sleep(10 * time.Second)
+			stats := q.Stats()
+			if stats.Success != int64(tt.count) {
+				t.Log(stats)
+				t.Errorf("Not all records were success. expected: %d, actual: %d", tt.count, stats.Success)
+			}
+			t.Log(q.Stats())
+		})
+	}
+}
+
+func TestQueue_DrainProcessPara(t *testing.T) {
+	tests := []struct {
+		name  string
+		count int
+		para  int
+	}{
+		{"parallel 2", 1000, 2},
+		{"parallel 10", 1000, 10},
+		{"parallel 100", 1000, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tf := &testFirehose{}
+			q := firequeue.New(tf, "env", firequeue.BatchInterval(1*time.Second))
+			ctx, cancel := context.WithCancel(context.Background())
+			go q.Loop(ctx)
+
+			time.Sleep(1000 * time.Millisecond)
+
+			for i := 0; i < tt.count; i++ {
+				err := q.Enqueue(&firehose.Record{
+					Data: []byte("test"),
+				})
+				if err != nil {
+					t.Errorf("error should not be occurred but: %s", err)
+				}
+			}
+			cancel()
+			time.Sleep(10 * time.Second)
+			stats := q.Stats()
+			if stats.Success != int64(tt.count) {
+				t.Log(stats)
+				t.Errorf("Not all records were success. expected: %d, actual: %d", tt.count, stats.Success)
+			}
+			t.Log(q.Stats())
+		})
 	}
 }

--- a/stats.go
+++ b/stats.go
@@ -3,7 +3,6 @@ package firequeue
 // Stats contains firequeue statistics.
 type Stats struct {
 	QueueLength      int
-	BatchLength      int
 	Success          int64
 	RetryCount       int64
 	UnretryableError int64

--- a/stats.go
+++ b/stats.go
@@ -3,9 +3,9 @@ package firequeue
 // Stats contains firequeue statistics.
 type Stats struct {
 	QueueLength      int
+	BatchLength      int
 	Success          int64
-	RetrySuccess     int64
+	RetryCount       int64
 	UnretryableError int64
 	QueueFullError   int64
-	GiveupError      int64
 }

--- a/stats.go
+++ b/stats.go
@@ -3,6 +3,7 @@ package firequeue
 // Stats contains firequeue statistics.
 type Stats struct {
 	QueueLength      int
+	BatchLength      int
 	Success          int64
 	RetryCount       int64
 	UnretryableError int64


### PR DESCRIPTION
The current implementation of firequeue sends requests from clients synchronously. I thought that sending requests asynchronously would reduce latency. Also, by sending requests in batch, the number of calls to the firehoseAPI can be reduced.Therefore, I made the following changes
1. client requests are only added to the queue and not sent.
2. add a worker to send batches from the queue at regular intervals.