### PR TITLE
be careful handling pointers

### DIFF
--- a/firequeue.go
+++ b/firequeue.go
@@ -304,7 +304,7 @@ func (q *Queue) attemptToSendBatch(batch []*firehose.Record) error {
 			return nil
 		}
 		// Retry failed records.
-		if resp != nil && *resp.FailedPutCount > 0 {
+		if resp != nil && resp.FailedPutCount != nil && *resp.FailedPutCount > 0 {
 			q.successCount.Add(int64(len(batch)) - int64(*resp.FailedPutCount))
 			q.retryFailedRecords(batch, resp)
 			return nil
@@ -320,7 +320,7 @@ func (q *Queue) retryFailedRecords(batch []*firehose.Record, resp *firehose.PutR
 	retryRecords := make([]*firehose.Record, 0, *resp.FailedPutCount)
 
 	for i, record := range batch {
-		if resp.RequestResponses[i].ErrorCode != nil {
+		if resp.RequestResponses != nil && resp.RequestResponses[i] != nil && resp.RequestResponses[i].ErrorCode != nil {
 			q.retryCount.Add(1)
 			retryRecords = append(retryRecords, record)
 		}


### PR DESCRIPTION
fix following panic issue

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19a9ddf]

goroutine 1225 [running]:
github.com/natureglobal/firequeue.(*Queue).attemptToSendBatch(0xc004ddaa80, {0xc004a82f00, 0x2d, 0x2d})
	github.com/natureglobal/firequeue@v0.0.6/firequeue.go:307 +0x19f
github.com/natureglobal/firequeue.(*Queue).sendBatch(0xc004ddaa80, {0x43a3d88, 0xc00421fc20})
	github.com/natureglobal/firequeue@v0.0.6/firequeue.go:263 +0x69
github.com/natureglobal/firequeue.(*Queue).loop(0xc004ddaa80, {0x43d5ba8, 0xc0000bd590})
	github.com/natureglobal/firequeue@v0.0.6/firequeue.go:204 +0xc7
github.com/natureglobal/firequeue.(*Queue).Loop.func1()
	github.com/natureglobal/firequeue@v0.0.6/firequeue.go:169 +0x55
created by github.com/natureglobal/firequeue.(*Queue).Loop in goroutine 1223
	github.com/natureglobal/firequeue@v0.0.6/firequeue.go:167 +0x6e
```